### PR TITLE
feature/57-add-cors-setting-for-api

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,16 +1,10 @@
-# Be sure to restart your server when you modify this file.
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins 'http://localhost:5173', 'http://127.0.0.1:5173'
 
-# Avoid CORS issues when API is called from the frontend app.
-# Handle Cross-Origin Resource Sharing (CORS) in order to accept cross-origin AJAX requests.
-
-# Read more: https://github.com/cyu/rack-cors
-
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins "example.com"
-#
-#     resource "*",
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+    resource '*',
+      headers: :any,
+      methods: [:get, :post, :put, :patch, :delete, :options, :head],
+      credentials: true
+  end
+end


### PR DESCRIPTION
## フロントエンドとバックエンドAPIの統合
[#57](https://github.com/Kuriyama301/osakana-calendar/issues/57)

### 変更内容

1. CORS設定の更新
   - `api/config/initializers/cors.rb` ファイルを更新
   - フロントエンドのオリジン（`http://localhost:5173`）を許可

2. Vite設定の調整
   - `front/app/vite.config.js` ファイルを更新
   - サーバー設定を追加し、ホストとポートを指定
   - APIへのプロキシ設定を追加

3. Docker Compose設定の修正
   - `docker-compose.yml` ファイルを更新
   - フロントエンドのポートマッピングを `5173:5173` に変更
   - 環境変数の設定を追加

4. 環境変数の設定
   - `.env.development` ファイルを更新
   - `API_URL` 環境変数を追加

5. フロントエンドのポート変更
   - アプリケーションへのアクセスを `http://localhost:5173/` に変更