### PR TITLE
Fix/138 calendar api for api

### DIFF
--- a/app/controllers/api/v1/calendar_controller.rb
+++ b/app/controllers/api/v1/calendar_controller.rb
@@ -1,19 +1,7 @@
 class Api::V1::CalendarController < ApplicationController
   def fish_by_date
     date = Date.parse(params[:date])
-    Rails.logger.debug "Searching for fish on date: #{date}"
-
-    @fish = Fish.joins(:fish_seasons).where(
-      '(fish_seasons.start_month < fish_seasons.end_month AND ? BETWEEN fish_seasons.start_month AND fish_seasons.end_month) OR ' \
-      '(fish_seasons.start_month > fish_seasons.end_month AND (? >= fish_seasons.start_month OR ? <= fish_seasons.end_month)) OR ' \
-      '(fish_seasons.start_month = fish_seasons.end_month AND ' \
-      '((fish_seasons.start_month = ? AND fish_seasons.start_day <= ? AND fish_seasons.end_day >= ?) OR ' \
-      '(fish_seasons.start_month = ? AND ((fish_seasons.start_day <= ? AND fish_seasons.end_day >= ?) OR ' \
-      '(fish_seasons.start_day > fish_seasons.end_day AND (? >= fish_seasons.start_day OR ? <= fish_seasons.end_day))))))',
-      date.month, date.month, date.month, date.month, date.day, date.day, date.month, date.day, date.day, date.day, date.day
-    ).distinct
-
-    Rails.logger.debug "Found #{@fish.count} fish for the date"
+    @fish = Fish.in_season_on(date).includes(:fish_seasons)
 
     if @fish.empty?
       render json: { message: "No fish found for the specified date." }, status: :not_found
@@ -22,5 +10,8 @@ class Api::V1::CalendarController < ApplicationController
     end
   rescue ArgumentError
     render json: { error: "Invalid date format. Please use YYYY-MM-DD." }, status: :bad_request
+  rescue StandardError => e
+    Rails.logger.error "Error in fish_by_date: #{e.message}"
+    render json: { error: "An unexpected error occurred." }, status: :internal_server_error
   end
 end

--- a/app/controllers/api/v1/calendar_controller.rb
+++ b/app/controllers/api/v1/calendar_controller.rb
@@ -18,7 +18,7 @@ class Api::V1::CalendarController < ApplicationController
     if @fish.empty?
       render json: { message: "No fish found for the specified date." }, status: :not_found
     else
-      render json: @fish, include: :fish_seasons
+      render json: @fish.as_json(include: :fish_seasons, methods: :image_url)
     end
   rescue ArgumentError
     render json: { error: "Invalid date format. Please use YYYY-MM-DD." }, status: :bad_request

--- a/app/controllers/api/v1/fish_controller.rb
+++ b/app/controllers/api/v1/fish_controller.rb
@@ -1,44 +1,18 @@
 class Api::V1::FishController < ApplicationController
   def index
-    @fishes = Fish.all
-    @fishes = @fishes.where(season: params[:season]) if params[:season]
+    date = params[:date].present? ? Date.parse(params[:date]) : Date.today
+    @fishes = Fish.in_season_with_full_details(date)
     render json: @fishes
   end
 
   def show
     @fish = Fish.find(params[:id])
-    render json: @fish
+    render json: @fish.as_json(include: :fish_seasons, methods: :image_url)
   end
-
-  # 今後の実装で管理画面を追加する
-
-  # def create
-  #   @fish = Fish.new(fish_params)
-  #   if @fish.save
-  #     render json: @fish, status: :created
-  #   else
-  #     render json: @fish.errors, status: :unprocessable_entity
-  #   end
-  # end
-
-  # def update
-  #   @fish = Fish.find(params[:id])
-  #   if @fish.update(fish_params)
-  #     render json: @fish
-  #   else
-  #     render json: @fish.errors, status: :unprocessable_entity
-  #   end
-  # end
-
-  # def destroy
-  #   @fish = Fish.find(params[:id])
-  #   @fish.destroy
-  #   head :no_content
-  # end
 
   private
 
-  # def fish_params
-  #   params.require(:fish).permit(:name, :description, :image_url, :season)
-  # end
+  def fish_params
+    params.require(:fish).permit(:name, :features, :nutrition, :origin)
+  end
 end

--- a/app/models/fish.rb
+++ b/app/models/fish.rb
@@ -27,9 +27,7 @@ class Fish < ApplicationRecord
   end
 
   def image_url
-    if image.attached?
-      Rails.application.routes.url_helpers.rails_blob_url(image, only_path: true)
-    end
+    Rails.application.routes.url_helpers.rails_blob_url(image, only_path: true) if image.attached?
   end
 
   def season_info

--- a/app/models/fish.rb
+++ b/app/models/fish.rb
@@ -1,42 +1,17 @@
 class Fish < ApplicationRecord
-  has_many :fish_seasons, dependent: :destroy
+  has_many :fish_seasons
   has_one_attached :image
 
-  validates :name, presence: true, uniqueness: true
-  validates :features, presence: true
-  validates :nutrition, presence: true
-  validates :origin, presence: true
-
-  scope :in_season, ->(date) {
+  def self.in_season_on(date)
     joins(:fish_seasons).where(
-      '(fish_seasons.start_month < fish_seasons.end_month AND ? BETWEEN fish_seasons.start_month AND fish_seasons.end_month) OR ' \
-      '(fish_seasons.start_month > fish_seasons.end_month AND (? >= fish_seasons.start_month OR ? <= fish_seasons.end_month)) OR ' \
-      '(fish_seasons.start_month = fish_seasons.end_month AND ' \
-      '((fish_seasons.start_month = ? AND fish_seasons.start_day <= ? AND fish_seasons.end_day >= ?) OR ' \
-      '(fish_seasons.start_month = ? AND ((fish_seasons.start_day <= ? AND fish_seasons.end_day >= ?) OR ' \
-      '(fish_seasons.start_day > fish_seasons.end_day AND (? >= fish_seasons.start_day OR ? <= fish_seasons.end_day))))))',
-      date.month, date.month, date.month, date.month, date.day, date.day, date.month, date.day, date.day, date.day, date.day
-    )
-  }
-
-  def self.in_season_with_full_details(date)
-    in_season(date)
-      .select('fish.*, fish_seasons.start_month, fish_seasons.start_day, fish_seasons.end_month, fish_seasons.end_day')
-      .includes(:fish_seasons)
-      .with_attached_image
+      "(fish_seasons.start_month <= :month AND fish_seasons.end_month >= :month) OR " \
+      "(fish_seasons.start_month > fish_seasons.end_month AND " \
+      "(fish_seasons.start_month <= :month OR fish_seasons.end_month >= :month))",
+      month: date.month
+    ).distinct
   end
 
   def image_url
-    Rails.application.routes.url_helpers.rails_blob_url(image, only_path: true) if image.attached?
-  end
-
-  def season_info
-    current_season = fish_seasons.find { |season| season.in_season?(Date.today) }
-    return nil unless current_season
-
-    {
-      start_date: "#{current_season.start_month}月#{current_season.start_day}日",
-      end_date: "#{current_season.end_month}月#{current_season.end_day}日"
-    }
+    image.attached? ? Rails.application.routes.url_helpers.rails_blob_url(image) : nil
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -72,6 +72,7 @@ Rails.application.configure do
 
   # 新しい設定をここに追加
   config.active_storage.resolve_model_to_route = :rails_storage_proxy
+  config.active_storage.logger = ActiveSupport::Logger.new(STDOUT)
 
   config.action_dispatch.default_headers = {
     'Access-Control-Allow-Origin' => '*',


### PR DESCRIPTION
モーダルに魚情報を追加する
[#138](https://github.com/Kuriyama301/osakana-calendar/issues/138)
### 変更内容

1. ヘッダー部分の固定
   - ヘッダー部分に `sticky top-0` クラスを追加
   - コンテンツ部分を `flex-grow overflow-y-auto` で調整

2. 魚のイラスト表示の中央揃え
   - グリッドコンテナのクラスを調整：
     grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 sm:gap-6 px-0
   - 各魚のアイテムコンテナを調整：
     flex flex-col items-center justify-center text-center
   - イメージコンテナを調整：
     w-32 h-32 sm:w-40 sm:h-40 flex items-center justify-center mb-2
   - イメージのクラスを変更：
     max-w-full max-h-full object-contain rounded-lg